### PR TITLE
Added Markdown Filter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 // Plugin Imports
 const pluginDirectoryOutput = require("@11ty/eleventy-plugin-directory-output");
 const pluginEleventyNavigation = require("@11ty/eleventy-navigation");
+const markdownIt = require('markdown-it')
 
 // Filter Imports
 const filterFormatDate = require("./src/config/filters/formatDate");
@@ -41,6 +42,14 @@ module.exports = function (eleventyConfig) {
 
     // Turns a date from ISO format to a more human-readable one
     eleventyConfig.addFilter("formatDate", filterFormatDate);
+
+    // Formats markdown content into Rich Text HTML
+    eleventyConfig.addFilter("md", (content) => markdownIt({
+        html: true,
+        breaks: true,
+        linkify: true,
+        xhtmlOut: true
+    }).render(content));
 
     return {
         dir: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@11ty/eleventy-plugin-directory-output": "^1.0.1",
                 "cross-env": "^7.0.3",
                 "decap-server": "^3.0.1",
+                "markdown-it": "^14.0.0",
                 "netlify-plugin-cache": "^1.0.3",
                 "npm-run-all": "^4.1.5"
             }
@@ -145,6 +146,44 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/11ty"
             }
+        },
+        "node_modules/@11ty/eleventy/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "node_modules/@11ty/eleventy/node_modules/linkify-it": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+            "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+            "dependencies": {
+                "uc.micro": "^1.0.1"
+            }
+        },
+        "node_modules/@11ty/eleventy/node_modules/markdown-it": {
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
+            "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "~3.0.1",
+                "linkify-it": "^4.0.1",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.js"
+            }
+        },
+        "node_modules/@11ty/eleventy/node_modules/mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+        },
+        "node_modules/@11ty/eleventy/node_modules/uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
         },
         "node_modules/@11ty/lodash-custom": {
             "version": "4.17.21",
@@ -2165,11 +2204,11 @@
             "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
         },
         "node_modules/linkify-it": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-            "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
             "dependencies": {
-                "uc.micro": "^1.0.1"
+                "uc.micro": "^2.0.0"
             }
         },
         "node_modules/liquidjs": {
@@ -2259,24 +2298,36 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
-            "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.0.0.tgz",
+            "integrity": "sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==",
             "dependencies": {
                 "argparse": "^2.0.1",
-                "entities": "~3.0.1",
-                "linkify-it": "^4.0.1",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.0.0"
             },
             "bin": {
-                "markdown-it": "bin/markdown-it.js"
+                "markdown-it": "bin/markdown-it.mjs"
             }
         },
         "node_modules/markdown-it/node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "node_modules/markdown-it/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/maximatch": {
             "version": "0.1.0",
@@ -2320,9 +2371,9 @@
             }
         },
         "node_modules/mdurl": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
@@ -3132,6 +3183,14 @@
             "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
             "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="
         },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/qs": {
             "version": "6.11.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -3892,9 +3951,9 @@
             }
         },
         "node_modules/uc.micro": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.0.0.tgz",
+            "integrity": "sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig=="
         },
         "node_modules/uglify-js": {
             "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@11ty/eleventy-plugin-directory-output": "^1.0.1",
         "cross-env": "^7.0.3",
         "decap-server": "^3.0.1",
+        "markdown-it": "^14.0.0",
         "netlify-plugin-cache": "^1.0.3",
         "npm-run-all": "^4.1.5"
     }


### PR DESCRIPTION
Added markdown-it npm package and created a markdown filter to simplify transforming markdown content to Rich Text HTML.

EDIT: Applies for YAML and JSON Global Data Files needing markdown support

Example:
`<div>{{ content | md | safe }}</div>`