### PR TITLE
Footer link using wrong entry variable 'link' instead of correct 'url'

### DIFF
--- a/src/_includes/components/footer.html
+++ b/src/_includes/components/footer.html
@@ -12,7 +12,7 @@
                 {% set navPages = collections.all | eleventyNavigation %}
                 {% for entry in navPages %}
                     <li class="cs-li">
-                        <a href="{{ entry.link }}" class="cs-link">{{ entry.key }}</a>
+                        <a href="{{ entry.url }}" class="cs-link">{{ entry.key }}</a>
                     </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
Current version results in the footer navigation links linking to the page you are currently on. 